### PR TITLE
Background plane definition using coefficients (ax+by+cz+d=0)

### DIFF
--- a/geograsp/include/geograsp/GeoGrasp.h
+++ b/geograsp/include/geograsp/GeoGrasp.h
@@ -42,12 +42,16 @@ class GeoGrasp {
     ~GeoGrasp();
 
     void setBackgroundCloud(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr &cloud);
+    void setBackgroundPlaneCoeff(const pcl::ModelCoefficients & coefficients);
     void setObjectCloud(const pcl::PointCloud<pcl::PointXYZRGB>::Ptr &cloud);
     void setGrasps(const int & grasps);
     void setGripTipSize(const int & size);
 
     GraspConfiguration getGrasp(const int & index) const;
     GraspConfiguration getBestGrasp() const;
+
+    pcl::ModelCoefficients getObjectAxisCoeff() const;
+    pcl::ModelCoefficients getBackgroundPlaneCoeff() const;
 
     float getRanking(const int & index) const;
     float getBestRanking() const;

--- a/geograsp/lib/geograsp/GeoGrasp.cpp
+++ b/geograsp/lib/geograsp/GeoGrasp.cpp
@@ -34,6 +34,11 @@ void GeoGrasp::setBackgroundCloud(
   backgroundCloud = cloud;
 }
 
+void GeoGrasp::setBackgroundPlaneCoeff(
+    const pcl::ModelCoefficients & coefficients) {
+  *backgroundPlaneCoeff = coefficients;
+}
+
 void GeoGrasp::setObjectCloud(
     const pcl::PointCloud<pcl::PointXYZRGB>::Ptr &cloud) {
   objectCloud = cloud;
@@ -66,6 +71,14 @@ GraspConfiguration GeoGrasp::getBestGrasp() const {
   return this->getGrasp(0);
 }
 
+pcl::ModelCoefficients GeoGrasp::getObjectAxisCoeff() const {
+  return *objectAxisCoeff;
+}
+
+pcl::ModelCoefficients GeoGrasp::getBackgroundPlaneCoeff() const {
+  return *backgroundPlaneCoeff;
+}
+
 float GeoGrasp::getRanking(const int & index) const {
   float ranking;
 
@@ -95,7 +108,8 @@ void GeoGrasp::compute() {
             << " data points from object cloud" << "\n";
 
   // Background plane
-  computeCloudPlane(this->backgroundCloud, this->backgroundPlaneCoeff);
+  if (backgroundPlaneCoeff->values.size() == 0)
+    computeCloudPlane(this->backgroundCloud, this->backgroundPlaneCoeff);
 
   // Cloud plane filtering
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZRGB>);


### PR DESCRIPTION
The background plane can now be defined using a _pcl::ModelCoefficients_ structure, where the coefficient values are (a, b, c, d) from the general form equation of the plane: **a**x+**b**y+**c**z+**d**=0.

If these coefficients are defined before calling the compute() method, the process will not consider the background point cloud for the calculation.