### PR TITLE
Adds GraspPose calculus and rename configuration to GraspContacts.

### DIFF
--- a/geograsp/include/geograsp/GeoGrasp.h
+++ b/geograsp/include/geograsp/GeoGrasp.h
@@ -30,9 +30,15 @@
 #include <pcl/features/normal_3d_omp.h>
 #include <pcl/features/moment_of_inertia_estimation.h>
 
-struct GraspConfiguration {
+struct GraspContacts {
   pcl::PointXYZ firstPoint;
   pcl::PointXYZ secondPoint;
+};
+
+struct GraspPose {
+  Eigen::Vector3f firstPoint;
+  Eigen::Vector3f secondPoint;
+  Eigen::Affine3f midPointPose;
 };
 
 class GeoGrasp {
@@ -46,8 +52,10 @@ class GeoGrasp {
     void setGrasps(const int & grasps);
     void setGripTipSize(const int & size);
 
-    GraspConfiguration getBestGrasp() const;
-    std::vector<GraspConfiguration> getGrasps() const;
+    GraspContacts getBestGrasp() const;
+    std::vector<GraspContacts> getGrasps() const;
+
+    GraspPose getBestGraspPose() const;
 
     float getBestRanking() const;
     std::vector<float> getRankings() const;
@@ -79,7 +87,7 @@ class GeoGrasp {
     pcl::PointNormal firstGraspPoint;
     pcl::PointNormal secondGraspPoint;
 
-    std::vector<GraspConfiguration> graspPoints;
+    std::vector<GraspContacts> graspPoints;
     std::vector<float> rankings;
     std::vector<float> pointsDistance;
 
@@ -142,7 +150,7 @@ class GeoGrasp {
       const pcl::PointXYZ & centroidPoint,
       const pcl::PointCloud<pcl::PointNormal>::Ptr & firstNormalCloud,
       const pcl::PointCloud<pcl::PointNormal>::Ptr & secondNormalCloud,
-      const int & numGrasps, std::vector<GraspConfiguration> & bestGrasps,
+      const int & numGrasps, std::vector<GraspContacts> & bestGrasps,
       std::vector<float> & bestRanks);
 };
 

--- a/geograsp/package.xml
+++ b/geograsp/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>geograsp</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>The GeoGrasp package: a geometry-based method for computing grasping points on 3D point clouds</description>
 
   <maintainer email="brayan.impata@ua.es">Brayan Impata</maintainer>

--- a/geograsp/src/cloud_processor.cpp
+++ b/geograsp/src/cloud_processor.cpp
@@ -136,7 +136,8 @@ void cloudCallback(const sensor_msgs::PointCloud2ConstPtr & inputCloudMsg) {
       geoGraspPoints.compute();
 
       // Extract best pair of points
-      GraspConfiguration bestGrasp = geoGraspPoints.getBestGrasp();
+      GraspContacts bestGrasp = geoGraspPoints.getBestGrasp();
+      GraspPose bestPose = geoGraspPoints.getBestGraspPose();
 
       // Visualize the result
       pcl::visualization::PointCloudColorHandlerRGBField<pcl::PointXYZRGB> rgb(objectCloud);
@@ -154,6 +155,39 @@ void cloudCallback(const sensor_msgs::PointCloud2ConstPtr & inputCloudMsg) {
 
       viewer->addSphere(bestGrasp.firstPoint, 0.01, 0, 0, 255, objectLabel + "First best grasp point");
       viewer->addSphere(bestGrasp.secondPoint, 0.01, 255, 0, 0, objectLabel + "Second best grasp point");
+
+      pcl::ModelCoefficients axeX;
+      axeX.values.resize (6);    // We need 6 values
+      axeX.values[0] = bestPose.midPointPose.translation()[0];
+      axeX.values[1] = bestPose.midPointPose.translation()[1];
+      axeX.values[2] = bestPose.midPointPose.translation()[2];
+      axeX.values[3] = bestPose.midPointPose.linear()(0, 0);
+      axeX.values[4] = bestPose.midPointPose.linear()(1, 0);
+      axeX.values[5] = bestPose.midPointPose.linear()(2, 0);
+
+      viewer->addLine(axeX, objectLabel + "Pose axeX");
+
+      pcl::ModelCoefficients axeY;
+      axeY.values.resize (6);    // We need 6 values
+      axeY.values[0] = bestPose.midPointPose.translation()[0];
+      axeY.values[1] = bestPose.midPointPose.translation()[1];
+      axeY.values[2] = bestPose.midPointPose.translation()[2];
+      axeY.values[3] = bestPose.midPointPose.linear()(0, 1);
+      axeY.values[4] = bestPose.midPointPose.linear()(1, 1);
+      axeY.values[5] = bestPose.midPointPose.linear()(2, 1);
+
+      viewer->addLine(axeY, objectLabel + "Pose axeY");
+
+      pcl::ModelCoefficients axeZ;
+      axeZ.values.resize (6);    // We need 6 values
+      axeZ.values[0] = bestPose.midPointPose.translation()[0];
+      axeZ.values[1] = bestPose.midPointPose.translation()[1];
+      axeZ.values[2] = bestPose.midPointPose.translation()[2];
+      axeZ.values[3] = bestPose.midPointPose.linear()(0, 2);
+      axeZ.values[4] = bestPose.midPointPose.linear()(1, 2);
+      axeZ.values[5] = bestPose.midPointPose.linear()(2, 2);
+
+      viewer->addLine(axeZ, objectLabel + "Pose axeZ");
       
       objectNumber++;
     }


### PR DESCRIPTION
GraspContacts (previously named GraspConfiguration) only holds PCL points for the two contact points found. GraspPose is created for calculating a grasp pose using Eigen, as well as providing the contacts as Eigen points, which should be more easily included into a robotic pipeline. This pose is obtained from the orientation of the object and the orientation of the grasp, so it provides an approach vector. The translation of the pose is at the midpoint between the two contacts.